### PR TITLE
Updated camera-constrain.js to prevent vibration

### DIFF
--- a/src/camera-constrain.js
+++ b/src/camera-constrain.js
@@ -49,6 +49,14 @@ var CameraConstrains = augment.defclass({
       var limit = camera.y + (worldBounds.y - viewport.y);
       camera.y =  limit;
     }
+    
+    // Prevent viewport from vibrating rapidly if world bounds are smaller than viewport
+    if (viewport.width > worldBounds.width){
+      camera.x = worldBounds.x + worldBounds.width/2;
+    }
+    if (viewport.height > worldBounds.height){
+      camera.y = worldBounds.y + worldBounds.height/2;
+    }
   },
 
   update: function(camera){


### PR DESCRIPTION
Added additional constraint to camera constrain's limitToWorld function to handle the case where one or more axes of the view-port are larger than the world bounds. In that case the world is centered in the viewport on each of the offending axis.

This replaces the current behavior of the camera vibrating like mad as it bounces between trying to satisfy constraints being violated on both sides.
